### PR TITLE
In cases where timeDelta is negative or zero

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func (job *TinyCronJob) nap() {
 	if job.opts.verbose {
 		output(fmt.Sprintf("next job scheduled for %s", nextRun))
 	}
+	// In cases where DST is applied, timeDelta can become zero or negative.
+	if timeDelta <= 0 {
+		timeDelta = nextRun.Add(time.Hour).Sub(now)
+	}
 	time.Sleep(timeDelta)
 }
 


### PR DESCRIPTION
Hi, bcicen.

In cases where DST is applied, timeDelta can become zero or negative.
I've made a PR that simply adjusts timeDelta by one hour when it is negative or zero.

Currently, in tinycron, there is an issue with the `cronexpr` package. When creating the next time using `time.Date()` and the timezone is set to something like `America/New_York`, there is a problem when DST is applied. For example, when creating it for 2 o'clock on March 10, 2024, it should become 3 o'clock, but it becomes 1 o'clock instead. Consequently, in tinycron, there's a problem where timeDelta becomes negative when DST is applied. This results in goroutines being continuously spawned for about an hour without resting.

I reported the issue with `time.Date()` to the golang community, but I only received a response stating that skipping or repeating in the documentation is not guaranteed. Therefore, I attempted to modify `cronexpr`, but the repository was archived, making it difficult to make changes. So, I'm submitting a PR here instead.

Thanks.